### PR TITLE
[MODORDERS-1269] Replaced composite po lines

### DIFF
--- a/src/main/java/org/folio/mosaic/service/OrdersService.java
+++ b/src/main/java/org/folio/mosaic/service/OrdersService.java
@@ -27,7 +27,7 @@ public class OrdersService {
     // TODO: Merge the order template with the composite purchase order
 
     var createdOrder = ordersClient.createOrder(compositePurchaseOrder);
-    return createdOrder.getCompositePoLines().getFirst().getPoLineNumber();
+    return createdOrder.getPoLines().getFirst().getPoLineNumber();
   }
 
 }

--- a/src/test/java/org/folio/mosaic/controller/OrdersControllerTest.java
+++ b/src/test/java/org/folio/mosaic/controller/OrdersControllerTest.java
@@ -15,8 +15,8 @@ import org.folio.mosaic.service.OrdersService;
 import org.folio.mosaic.support.JsonUtils;
 import org.folio.mosaic.util.error.ErrorUtils;
 import org.folio.mosaic.util.error.ErrorCode;
-import org.folio.rest.acq.model.orders.CompositePoLine;
 import org.folio.rest.acq.model.orders.CompositePurchaseOrder;
+import org.folio.rest.acq.model.orders.PoLine;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -44,7 +44,7 @@ class OrdersControllerTest {
   @Test
   void testCreateOrder() throws Exception {
     val poLineNumber = "12345";
-    val mosaicOrder = new CompositePurchaseOrder().withCompositePoLines(List.of(new CompositePoLine().withPoLineNumber(poLineNumber)));
+    val mosaicOrder = new CompositePurchaseOrder().withPoLines(List.of(new PoLine().withPoLineNumber(poLineNumber)));
     var templateId = UUID.randomUUID();
 
     when(ordersService.createOrder(templateId, mosaicOrder)).thenReturn(poLineNumber);

--- a/src/test/java/org/folio/mosaic/service/OrdersServiceTest.java
+++ b/src/test/java/org/folio/mosaic/service/OrdersServiceTest.java
@@ -12,8 +12,8 @@ import java.util.UUID;
 import org.folio.mosaic.support.CopilotGenerated;
 import org.folio.mosaic.client.OrdersClient;
 import org.folio.rest.acq.model.mosaic.MosaicConfiguration;
-import org.folio.rest.acq.model.orders.CompositePoLine;
 import org.folio.rest.acq.model.orders.CompositePurchaseOrder;
+import org.folio.rest.acq.model.orders.PoLine;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -40,7 +40,7 @@ class OrdersServiceTest {
     var templateId = UUID.randomUUID();
 
     CompositePurchaseOrder createdOrder = new CompositePurchaseOrder();
-    createdOrder.setCompositePoLines(List.of(new CompositePoLine().withPoLineNumber("POL12345")));
+    createdOrder.setPoLines(List.of(new PoLine().withPoLineNumber("POL12345")));
 
     when(ordersClient.createOrder(compositePurchaseOrder)).thenReturn(createdOrder);
 
@@ -57,7 +57,7 @@ class OrdersServiceTest {
     var templateId = UUID.randomUUID();
 
     CompositePurchaseOrder createdOrder = new CompositePurchaseOrder();
-    createdOrder.setCompositePoLines(List.of(new CompositePoLine().withPoLineNumber("POL12345")));
+    createdOrder.setPoLines(List.of(new PoLine().withPoLineNumber("POL12345")));
 
     when(ordersClient.getOrderTemplateById(any())).thenReturn(compositePurchaseOrder);
     when(ordersClient.createOrder(compositePurchaseOrder)).thenReturn(createdOrder);
@@ -75,7 +75,7 @@ class OrdersServiceTest {
     var defaultTemplateId = UUID.randomUUID();
 
     CompositePurchaseOrder createdOrder = new CompositePurchaseOrder();
-    createdOrder.setCompositePoLines(List.of(new CompositePoLine().withPoLineNumber("POL12345")));
+    createdOrder.setPoLines(List.of(new PoLine().withPoLineNumber("POL12345")));
 
     when(configurationService.getConfiguration()).thenReturn(new MosaicConfiguration().withDefaultTemplateId(defaultTemplateId.toString()));
     when(ordersClient.getOrderTemplateById(any())).thenReturn(compositePurchaseOrder);


### PR DESCRIPTION
## Purpose
[MODORDERS-1269](https://folio-org.atlassian.net/browse/MODORDERS-1269) - Remove alerts and reporting codes from order lines, use a single order line schema

## Approach
- Replaced composite po lines by po lines.

## Related PRs
- See [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/477)

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
