### PR TITLE
[EDGORDERS-96-2]. Fix invalid schema method

### DIFF
--- a/src/main/java/org/folio/mosaic/controller/ValidationController.java
+++ b/src/main/java/org/folio/mosaic/controller/ValidationController.java
@@ -5,7 +5,6 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.mosaic.domain.dto.MosaicValidation;
 import org.folio.mosaic.rest.resource.ValidateApi;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,7 +18,6 @@ import static org.springframework.http.HttpStatus.OK;
 public class ValidationController implements ValidateApi {
 
   @Override
-  @GetMapping(value = "/validate")
   public ResponseEntity<MosaicValidation> getValidation() {
     var result = new MosaicValidation();
     result.setStatus(SUCCESS);

--- a/src/main/resources/swagger.api/mosaic.yaml
+++ b/src/main/resources/swagger.api/mosaic.yaml
@@ -9,7 +9,7 @@ paths:
   ### Validation ###
   /validate:
     description: Validation API
-    post:
+    get:
       summary: Validate a request coming from edge-orders by checking for a valid API Key and User-attached permissions
       operationId: getValidation
       responses:


### PR DESCRIPTION
## Purpose

- Fix invalid schema method definition

## Approach 

- Remove @GetMapping & fix `/validate` definition in  `resources/swagger.api/mosaic.yam`