### PR TITLE
[MODMO-14]. Cover mosaic integrations with Karate tests

### DIFF
--- a/src/main/java/org/folio/mosaic/service/MosaicOrderConverter.java
+++ b/src/main/java/org/folio/mosaic/service/MosaicOrderConverter.java
@@ -103,6 +103,10 @@ public class MosaicOrderConverter {
     if (mosaicOrder.getVendor() != null) {
       order.setVendor(mosaicOrder.getVendor());
     }
+    if (mosaicOrder.getWorkflowStatus() != null) {
+      var workflowStatus = mosaicOrder.getWorkflowStatus().name();
+      order.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.valueOf(workflowStatus));
+    }
     if (mosaicOrder.getBillTo() != null) {
       order.setBillTo(mosaicOrder.getBillTo());
     }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODMO-14>

## Approach

- Allow WorkflowStatus field on MosaicOrder to be overridden
- Update unit tests