### PR TITLE
[MODMO-15-5]. Fix POL Cost mapping on null format in MosaicOrder

### DIFF
--- a/src/main/java/org/folio/mosaic/service/MosaicOrderConverter.java
+++ b/src/main/java/org/folio/mosaic/service/MosaicOrderConverter.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.rest.acq.model.mosaic.MosaicOrder;
 import org.folio.rest.acq.model.orders.CompositePurchaseOrder;
@@ -53,7 +54,7 @@ public class MosaicOrderConverter {
     log.debug("createOrderFromTemplatePair:: Creating order from template: {}", templatePair.getKey().getId());
 
     var orderTemplate = templatePair.getKey();
-    var orderType = orderTemplate.getOrderType() != null
+    var orderType = ObjectUtils.isNotEmpty(orderTemplate.getOrderType())
       ? orderTemplate.getOrderType() : CompositePurchaseOrder.OrderType.ONE_TIME;
     var poLine = mosaicPoLineConverter.createPoLineFromTemplate(templatePair.getValue());
 
@@ -97,29 +98,29 @@ public class MosaicOrderConverter {
    * @param mosaicOrder The request containing override values
    */
   public void applyOverrides(CompositePurchaseOrder order, MosaicOrder mosaicOrder) {
-    if (mosaicOrder.getId() != null) {
+    if (ObjectUtils.isNotEmpty(mosaicOrder.getId())) {
       order.setId(mosaicOrder.getId());
     }
-    if (mosaicOrder.getAssignedTo() != null) {
+    if (ObjectUtils.isNotEmpty(mosaicOrder.getAssignedTo())) {
       order.setAssignedTo(mosaicOrder.getAssignedTo());
     }
-    if (mosaicOrder.getVendor() != null) {
+    if (ObjectUtils.isNotEmpty(mosaicOrder.getVendor())) {
       order.setVendor(mosaicOrder.getVendor());
     }
-    if (mosaicOrder.getWorkflowStatus() != null) {
+    if (ObjectUtils.isNotEmpty(mosaicOrder.getWorkflowStatus())) {
       var workflowStatus = mosaicOrder.getWorkflowStatus().name();
       order.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.valueOf(workflowStatus));
     }
-    if (mosaicOrder.getBillTo() != null) {
+    if (ObjectUtils.isNotEmpty(mosaicOrder.getBillTo())) {
       order.setBillTo(mosaicOrder.getBillTo());
     }
-    if (mosaicOrder.getShipTo() != null) {
+    if (ObjectUtils.isNotEmpty(mosaicOrder.getShipTo())) {
       order.setShipTo(mosaicOrder.getShipTo());
     }
     if (CollectionUtils.isNotEmpty(mosaicOrder.getAcqUnitIds())) {
       order.setAcqUnitIds(mosaicOrder.getAcqUnitIds());
     }
-    if (mosaicOrder.getCustomFields() != null) {
+    if (ObjectUtils.isNotEmpty(mosaicOrder.getCustomFields())) {
       var convertedCustomFields = new CustomFields();
       mosaicOrder.getCustomFields().getAdditionalProperties().forEach(convertedCustomFields::withAdditionalProperty);
       order.setCustomFields(convertedCustomFields);

--- a/src/main/java/org/folio/mosaic/service/MosaicPoLineConverter.java
+++ b/src/main/java/org/folio/mosaic/service/MosaicPoLineConverter.java
@@ -24,8 +24,6 @@ import java.util.UUID;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.folio.rest.acq.model.mosaic.MosaicOrder.OrderFormat.ELECTRONIC_RESOURCE;
-import static org.folio.rest.acq.model.mosaic.MosaicOrder.OrderFormat.P_E_MIX;
 
 @Log4j2
 @Service
@@ -156,14 +154,14 @@ public class MosaicPoLineConverter {
     if (ObjectUtils.isEmpty(mosaicOrder.getListUnitPrice()) && ObjectUtils.isEmpty(mosaicOrder.getListUnitPriceElectronic())) {
       return;
     }
-    var cost = poLine.getCost() != null ? poLine.getCost() : new Cost();
-    var orderFormat = mosaicOrder.getFormat();
+    var cost = ObjectUtils.isNotEmpty(poLine.getCost()) ? poLine.getCost() : new Cost();
+    var orderFormat = poLine.getOrderFormat();
 
-    if (orderFormat == ELECTRONIC_RESOURCE && mosaicOrder.getListUnitPriceElectronic() != null) {
+    if (orderFormat == OrderFormat.ELECTRONIC_RESOURCE && ObjectUtils.isNotEmpty(mosaicOrder.getListUnitPriceElectronic())) {
       cost.setListUnitPriceElectronic(mosaicOrder.getListUnitPriceElectronic());
       cost.setQuantityElectronic(mosaicOrder.getQuantityElectronic());
       cost.setQuantityPhysical(0);
-    } else if (orderFormat == P_E_MIX) {
+    } else if (orderFormat == OrderFormat.P_E_MIX) {
       cost.setListUnitPrice(mosaicOrder.getListUnitPrice());
       cost.setListUnitPriceElectronic(mosaicOrder.getListUnitPriceElectronic());
       cost.setQuantityPhysical(mosaicOrder.getQuantityPhysical());

--- a/src/test/java/org/folio/mosaic/service/MosaicConverterTest.java
+++ b/src/test/java/org/folio/mosaic/service/MosaicConverterTest.java
@@ -1241,6 +1241,45 @@ class MosaicConverterTest {
       poLine.getEresource().getCreateInventory());
   }
 
+  @Test
+  void testUpdatePoLineCost_withNullOrderFormat() {
+    // Setup test data
+    var templateId = UUID.randomUUID().toString();
+    var orderTemplate = new CompositePurchaseOrder()
+      .withId(templateId);
+
+    var poLineTemplate = new PoLine()
+      .withTitleOrPackage("Default Title")
+      .withOrderFormat(null)  // Explicitly set order format to null
+      .withCost(new Cost()
+        .withListUnitPrice(10.0)
+        .withCurrency("USD")
+        .withQuantityPhysical(1)
+        .withQuantityElectronic(0));
+
+    var templatePair = Pair.of(orderTemplate, poLineTemplate);
+
+    // Create MosaicOrder with cost override values
+    var mosaicOrder = new MosaicOrder()
+      .withTitle("Cost Test")
+      .withFormat(null)  // Explicitly set format to null
+      .withListUnitPrice(20.0)
+      .withQuantityPhysical(2)
+      .withCurrency("EUR");
+
+    // Convert to CompositePurchaseOrder
+    var result = mosaicOrderConverter.convertToCompositePurchaseOrder(mosaicOrder, templatePair);
+    var resultPoLine = result.getPoLines().getFirst();
+
+    // Verify cost values were properly set despite null order format
+    assertNotNull(resultPoLine.getCost());
+    assertEquals(20.0, resultPoLine.getCost().getListUnitPrice());
+    assertEquals(2, resultPoLine.getCost().getQuantityPhysical());
+    assertEquals(0, resultPoLine.getCost().getQuantityElectronic());
+    assertEquals("EUR", resultPoLine.getCost().getCurrency());
+    assertNull(resultPoLine.getCost().getListUnitPriceElectronic());
+  }
+
   private PoLine createPoLineTemplate(boolean checkinItemsValue) {
     var vendorDetail = new VendorDetail();
     var referenceNumbers = List.of(new org.folio.rest.acq.model.orders.ReferenceNumberItem()


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODMO-15>

## Approach

- Change order format checking during POL Cost mapping to use order format on the POL
- The order format on the POL already has the template default value
- Replace null checks with a standardized ObjectUtils.isNotEmpty