### PR TITLE
[EDGORDERS-101]. Change mosaic order schema to account for PO/POL custom fields

### DIFF
--- a/src/main/java/org/folio/mosaic/service/MosaicOrderConverter.java
+++ b/src/main/java/org/folio/mosaic/service/MosaicOrderConverter.java
@@ -1,6 +1,8 @@
 package org.folio.mosaic.service;
 
 import static java.util.Collections.singletonList;
+import static org.folio.mosaic.util.error.CustomFieldsUtil.getCustomFieldsByEntityType;
+import static org.folio.rest.acq.model.mosaic.MosaicCustomFields.EntityType.PURCHASE_ORDER;
 
 import java.util.ArrayList;
 import java.util.UUID;
@@ -12,7 +14,6 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.rest.acq.model.mosaic.MosaicOrder;
 import org.folio.rest.acq.model.orders.CompositePurchaseOrder;
-import org.folio.rest.acq.model.orders.CustomFields;
 import org.folio.rest.acq.model.orders.PoLine;
 import org.springframework.stereotype.Service;
 
@@ -121,9 +122,8 @@ public class MosaicOrderConverter {
       order.setAcqUnitIds(mosaicOrder.getAcqUnitIds());
     }
     if (ObjectUtils.isNotEmpty(mosaicOrder.getCustomFields())) {
-      var convertedCustomFields = new CustomFields();
-      mosaicOrder.getCustomFields().getAdditionalProperties().forEach(convertedCustomFields::withAdditionalProperty);
-      order.setCustomFields(convertedCustomFields);
+      var customFields = getCustomFieldsByEntityType(mosaicOrder, PURCHASE_ORDER);
+      order.setCustomFields(customFields);
     }
 
     mosaicPoLineConverter.applyOverridesToPoLine(order, mosaicOrder);

--- a/src/main/java/org/folio/mosaic/service/MosaicPoLineConverter.java
+++ b/src/main/java/org/folio/mosaic/service/MosaicPoLineConverter.java
@@ -24,6 +24,8 @@ import java.util.UUID;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.folio.mosaic.util.error.CustomFieldsUtil.getCustomFieldsByEntityType;
+import static org.folio.rest.acq.model.mosaic.MosaicCustomFields.EntityType.PO_LINE;
 
 @Log4j2
 @Service
@@ -127,6 +129,10 @@ public class MosaicPoLineConverter {
     }
     if (ObjectUtils.isNotEmpty(mosaicOrder.getCheckinItems())) {
       poLine.setCheckinItems(mosaicOrder.getCheckinItems());
+    }
+    if (ObjectUtils.isNotEmpty(mosaicOrder.getCustomFields())) {
+      var customFields = getCustomFieldsByEntityType(mosaicOrder, PO_LINE);
+      poLine.setCustomFields(customFields);
     }
 
     updatePoLineOrderFormat(mosaicOrder, poLine);

--- a/src/main/java/org/folio/mosaic/util/error/CustomFieldsUtil.java
+++ b/src/main/java/org/folio/mosaic/util/error/CustomFieldsUtil.java
@@ -1,0 +1,18 @@
+package org.folio.mosaic.util.error;
+
+import lombok.experimental.UtilityClass;
+import org.folio.rest.acq.model.mosaic.MosaicCustomFields;
+import org.folio.rest.acq.model.mosaic.MosaicOrder;
+import org.folio.rest.acq.model.orders.CustomFields;
+
+@UtilityClass
+public class CustomFieldsUtil {
+
+  public static CustomFields getCustomFieldsByEntityType(MosaicOrder mosaicOrder, MosaicCustomFields.EntityType entityType) {
+    var convertedCustomFields = new CustomFields();
+    mosaicOrder.getCustomFields().stream()
+      .filter(field -> field.getEntityType() == entityType)
+      .forEach(customField -> convertedCustomFields.withAdditionalProperty(customField.getRefId(), customField.getValue()));
+    return convertedCustomFields;
+  }
+}


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/EDGORDERS-101>

## Approach

- Change PO and POL mapping of the custom fields to accept a json object

![image](https://github.com/user-attachments/assets/893c92a2-3950-43fd-bfd3-2f71be5ca370)

- Update unit tests