### PR TITLE
TCR-57. Add more fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Copyright (C) 2025 The Open Library Foundation
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
+This software uses a copyleft (LGPL-2.1-or-later) licensed software library: org.hibernate.orm:hibernate-core
+
 ## Table of contents
 
 * [Introduction](#introduction)
@@ -19,6 +21,53 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 ## Introduction
 
 This module provides a functionality to integrate with Mosaic ordering system.
+
+## Installing and deployment
+
+### Compiling
+
+```shell
+mvn install
+```
+
+See that it says "BUILD SUCCESS" near the end.
+
+
+### Running it
+
+Run locally with proper environment variables set (see
+[Environment variables](#environment-variables) below) on listening port 8081 (default
+listening port):
+
+```
+java -Dserver.port=8081 -jar target/mod-mosaic-*.jar
+```
+
+### Docker
+
+Build the docker container with:
+
+```shell
+docker build -t mod-mosaic .
+```
+
+Test that it runs with:
+
+```shell
+docker run -t -i -p 8081:8081 mod-mosaic
+```
+
+### Environment variables
+
+| Name          | Default value | Description                                                                                                                                                                   |
+|:--------------|:-------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DB_HOST       |   postgres    | Postgres hostname                                                                                                                                                             |
+| DB_PORT       |     5432      | Postgres port                                                                                                                                                                 |
+| DB_USERNAME   |  folio_admin  | Postgres username                                                                                                                                                             |
+| DB_PASSWORD   |       -       | Postgres username password                                                                                                                                                    |
+| DB_DATABASE   | okapi_modules | Postgres database name                                                                                                                                                        |
+| OKAPI_URL     |       -       | Okapi url                                                                                                                                                                     |
+| ENV           |     folio     | The logical name of the deployment, must be unique across all environments using the same shared Kafka/Elasticsearch clusters, a-z (any case), 0-9, -, _ symbols only allowed |
 
 ## Additional Information
 ### Issue tracker

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -7,24 +7,8 @@
       "version": "13.0"
     },
     {
-      "id": "order-lines",
-      "version": "4.0"
-    },
-    {
       "id": "order-templates",
       "version": "1.0"
-    },
-    {
-      "id": "organizations.organizations",
-      "version": "1.1"
-    },
-    {
-      "id": "finance.expense-classes",
-      "version": "3.0"
-    },
-    {
-      "id": "finance.funds",
-      "version": "3.0"
     }
   ],
   "provides": [


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/TCR-57

### **Approach**
Fixing these comments:
Regarding the third party dependencies criterium: org.hibernate.orm:hibernate-core:6.6.13.Final uses LGPL-2.1-or-later, therefore mod-mosaic need to use README for [Category B Appropriately Labelled Condition](https://apache.org/legal/resolved.html#appropriately-labelled-condition).

README should list environment variables (criterium “Installation documentation is included”)


https://github.com/folio-org/mod-mosaic/blob/TCR-57/src/main/java/org/folio/mosaic/client/OrdersClient.java  uses 2 APIs, but 
[mod-mosaic/descriptors/ModuleDescriptor-template.json at TCR-57 · folio-org/mod-mosaic](https://github.com/folio-org/mod-mosaic/blob/TCR-57/descriptors/ModuleDescriptor-template.json)
lists 6 required interfaces, where are the other 4 APIs been used?

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
