### PR TITLE
Add missed orders approve permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -32,6 +32,7 @@
           ],
           "modulePermissions": [
             "orders.order-templates.collection.get",
+            "orders.item.approve",
             "orders.item.post"
           ]
         },


### PR DESCRIPTION
### **Purpose**
Fix this error

<Response>     <Error>         <Code>BAD_REQUEST</Code>         <Message>{"errors":[{"message":"[403 Forbidden] during [POST] to [http://orders/composite-orders] [OrdersClient#createOrder(CompositePurchaseOrder)]: [{\n  \"errors\" : [ {\n    \"message\" : \"User does not have permissions to approve order - operation is restricted\",\n    \"code\" : \"userHasNoApprovalPermission\",\n    \"parameters\" : [ ]\n  } ],\n  \"total_records\" : 1\n}]","code":"badRequestError","parameters":[]}],"total_records":1}</Message>     </Error> </Response>

### **Approach**
Corresponding mod-orders check:
https://github.com/folio-org/mod-orders/blob/master/src/main/java/org/folio/orders/utils/PermissionsUtil.java#L12
---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
