### PR TITLE
MODMO-19. Add missed interface to create default organization during startup

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,6 +9,10 @@
     {
       "id": "order-templates",
       "version": "1.0"
+    },
+    {
+      "id": "organizations.organizations",
+      "version": "1.2"
     }
   ],
   "provides": [


### PR DESCRIPTION

### **Purpose**
Add missed inteface in ModuleDescriptor. It used here:
https://github.com/folio-org/mod-mosaic/blob/master/src/main/java/org/folio/mosaic/service/OrganizationService.java

### **Approach**
Provide a brief technical summary of the changes.

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
