### PR TITLE
[MODMO-21] Enhancements for Mosaic integration

### DIFF
--- a/src/main/java/org/folio/mosaic/service/MosaicOrderConverter.java
+++ b/src/main/java/org/folio/mosaic/service/MosaicOrderConverter.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.rest.acq.model.mosaic.MosaicOrder;
 import org.folio.rest.acq.model.orders.CompositePurchaseOrder;
+import org.folio.rest.acq.model.orders.Ongoing;
 import org.folio.rest.acq.model.orders.PoLine;
 import org.springframework.stereotype.Service;
 
@@ -57,6 +58,10 @@ public class MosaicOrderConverter {
     var orderTemplate = templatePair.getKey();
     var orderType = ObjectUtils.isNotEmpty(orderTemplate.getOrderType())
       ? orderTemplate.getOrderType() : CompositePurchaseOrder.OrderType.ONE_TIME;
+    var ongoing = orderTemplate.getOngoing();
+    if (orderType == CompositePurchaseOrder.OrderType.ONGOING && ObjectUtils.isEmpty(ongoing)) {
+      ongoing = new Ongoing();
+    }
     var poLine = mosaicPoLineConverter.createPoLineFromTemplate(templatePair.getValue());
 
     return new CompositePurchaseOrder()
@@ -74,7 +79,7 @@ public class MosaicOrderConverter {
       .withPoNumberSuffix(orderTemplate.getPoNumberSuffix())
       .withOrderType(orderType)
       .withReEncumber(orderTemplate.getReEncumber())
-      .withOngoing(orderTemplate.getOngoing())
+      .withOngoing(ongoing)
       .withShipTo(orderTemplate.getShipTo())
       .withTemplate(orderTemplate.getId())
       .withTotalCredited(orderTemplate.getTotalCredited())

--- a/src/main/java/org/folio/mosaic/service/MosaicPoLineConverter.java
+++ b/src/main/java/org/folio/mosaic/service/MosaicPoLineConverter.java
@@ -166,16 +166,24 @@ public class MosaicPoLineConverter {
 
     if (orderFormat == OrderFormat.ELECTRONIC_RESOURCE && ObjectUtils.isNotEmpty(mosaicOrder.getListUnitPriceElectronic())) {
       cost.setListUnitPriceElectronic(mosaicOrder.getListUnitPriceElectronic());
-      cost.setQuantityElectronic(mosaicOrder.getQuantityElectronic());
+      if (ObjectUtils.isNotEmpty(mosaicOrder.getQuantityElectronic())) {
+        cost.setQuantityElectronic(mosaicOrder.getQuantityElectronic());
+      }
       cost.setQuantityPhysical(0);
     } else if (orderFormat == OrderFormat.P_E_MIX) {
       cost.setListUnitPrice(mosaicOrder.getListUnitPrice());
       cost.setListUnitPriceElectronic(mosaicOrder.getListUnitPriceElectronic());
-      cost.setQuantityPhysical(mosaicOrder.getQuantityPhysical());
-      cost.setQuantityElectronic(mosaicOrder.getQuantityElectronic());
+      if (ObjectUtils.isNotEmpty(mosaicOrder.getQuantityPhysical())) {
+        cost.setQuantityPhysical(mosaicOrder.getQuantityPhysical());
+      }
+      if (ObjectUtils.isNotEmpty(mosaicOrder.getQuantityElectronic())) {
+        cost.setQuantityElectronic(mosaicOrder.getQuantityElectronic());
+      }
     } else {
       cost.setListUnitPrice(mosaicOrder.getListUnitPrice());
-      cost.setQuantityPhysical(mosaicOrder.getQuantityPhysical());
+      if (ObjectUtils.isNotEmpty(mosaicOrder.getQuantityPhysical())) {
+        cost.setQuantityPhysical(mosaicOrder.getQuantityPhysical());
+      }
       cost.setQuantityElectronic(0);
     }
 

--- a/src/test/java/org/folio/mosaic/service/MosaicConverterTest.java
+++ b/src/test/java/org/folio/mosaic/service/MosaicConverterTest.java
@@ -1298,6 +1298,66 @@ class MosaicConverterTest {
     assertNull(resultPoLine.getCost().getListUnitPriceElectronic());
   }
 
+
+
+  @Test
+  void testElectronicQuantityPreservedFromTemplateWhenNotInRequest() {
+    var templateId = UUID.randomUUID().toString();
+    var orderTemplate = new CompositePurchaseOrder()
+      .withId(templateId);
+
+    var poLineTemplate = new PoLine()
+      .withTitleOrPackage("Default Title")
+      .withOrderFormat(OrderFormat.ELECTRONIC_RESOURCE)
+      .withCost(new Cost()
+        .withListUnitPriceElectronic(10.0)
+        .withCurrency("USD")
+        .withQuantityElectronic(1)
+        .withQuantityPhysical(0));
+
+    var templatePair = Pair.of(orderTemplate, poLineTemplate);
+
+    // Request provides price but NOT quantityElectronic
+    var mosaicOrder = new MosaicOrder()
+      .withTitle("Advanced Database Systems")
+      .withListUnitPriceElectronic(88.88);
+
+    var result = mosaicOrderConverter.convertToCompositePurchaseOrder(mosaicOrder, templatePair);
+    var resultPoLine = result.getPoLines().getFirst();
+
+    assertEquals(OrderFormat.ELECTRONIC_RESOURCE, resultPoLine.getOrderFormat());
+    assertEquals(88.88, resultPoLine.getCost().getListUnitPriceElectronic());
+    assertEquals(1, resultPoLine.getCost().getQuantityElectronic());
+    assertEquals(0, resultPoLine.getCost().getQuantityPhysical());
+  }
+
+  @Test
+  void testOngoingOrderTypeWithoutOngoingFieldSetsDefault() {
+    var templateId = UUID.randomUUID().toString();
+    var orderTemplate = new CompositePurchaseOrder()
+      .withId(templateId)
+      .withOrderType(CompositePurchaseOrder.OrderType.ONGOING)
+      .withVendor("test-vendor");
+
+    var poLineTemplate = new PoLine()
+      .withTitleOrPackage("Default Title")
+      .withOrderFormat(OrderFormat.ELECTRONIC_RESOURCE)
+      .withCost(new Cost()
+        .withListUnitPriceElectronic(10.0)
+        .withCurrency("USD")
+        .withQuantityElectronic(1));
+
+    var templatePair = Pair.of(orderTemplate, poLineTemplate);
+
+    var mosaicOrder = new MosaicOrder()
+      .withTitle("Ongoing Order Test");
+
+    var result = mosaicOrderConverter.convertToCompositePurchaseOrder(mosaicOrder, templatePair);
+
+    assertEquals(CompositePurchaseOrder.OrderType.ONGOING, result.getOrderType());
+    assertNotNull(result.getOngoing());
+  }
+
   private PoLine createPoLineTemplate(boolean checkinItemsValue) {
     var vendorDetail = new VendorDetail();
     var referenceNumbers = List.of(new org.folio.rest.acq.model.orders.ReferenceNumberItem()


### PR DESCRIPTION
## Purpose
[[MODMO-21] Enhancements for Mosaic integration](https://folio-org.atlassian.net/browse/MODMO-21)

## Approach
- Fix template `quantityElectronic`/`quantityPhysical` values being overwritten with null when not provided in the request
- Fix `Ongoing` order type failing validation when the template does not explicitly include the `ongoing` object